### PR TITLE
Add daydreamer-json/ak-endfield-gacha-link-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ If you are looking for content related to [Arknights](https://ak.hypergryph.com/
   - [Vercel](https://ak-endfield-puzzle.vercel.app/)
   - Endfield puzzle solving tool.
   - Backend repository [SihenZhang/ak-endfield-puzzle-api](https://github.com/SihenZhang/ak-endfield-puzzle-api)
+- [daydreamer-json/ak-endfield-gacha-link-gen](https://github.com/daydreamer-json/ak-endfield-gacha-link-gen)
+  - Scripts to retrieve the Arknights: Endfield gacha history URL for gacha history management services.
 
 ## Contributing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,9 @@
   - [Vercel](https://ak-endfield-puzzle.vercel.app/)
   - 终末地拼图解谜工具
   - 后端仓库 [SihenZhang/ak-endfield-puzzle-api](https://github.com/SihenZhang/ak-endfield-puzzle-api)
+- [daydreamer-json/ak-endfield-gacha-link-gen](https://github.com/daydreamer-json/ak-endfield-gacha-link-gen)
+  - 用于获取《明日方舟：终末地》扭蛋记录URL的脚本，供扭蛋记录管理服务使用。
+
 
 ## 贡献
 

--- a/data/LIST.json
+++ b/data/LIST.json
@@ -301,5 +301,24 @@
     "id": 11,
     "addedAt": "2026-01-19",
     "openSource": true
+  },
+  {
+    "name": "daydreamer-json/ak-endfield-gacha-link-gen",
+    "description": {
+      "en-US": "Scripts to retrieve the Arknights: Endfield gacha history URL for gacha history management services.",
+      "zh-CN": "用于获取《明日方舟：终末地》扭蛋记录URL的脚本，供扭蛋记录管理服务使用。"
+    },
+    "repository": "https://github.com/daydreamer-json/ak-endfield-gacha-link-gen",
+    "author": {
+      "name": "daydreamer-json",
+      "url": "https://github.com/daydreamer-json"
+    },
+    "category": "Auxiliary Tools",
+    "tags": [
+      "Gacha"
+    ],
+    "id": 12,
+    "addedAt": "2026-01-25",
+    "openSource": true
   }
 ]


### PR DESCRIPTION
Add the repository containing a simple script for extracting Endfield's gacha history URLs to the list.

- [x] The project I am adding is not already listed in this repository
- [x] I have searched the repository's [Issues](https://github.com/palmcivet/awesome-arknights-endfield/issues) and [Pull Requests](https://github.com/palmcivet/awesome-arknights-endfield/pulls), including open and closed ones
- [x] I have read the contributing guidelines [CONTRIBUTING.md](https://github.com/palmcivet/awesome-arknights-endfield/blob/main/CONTRIBUTING.md) and the addition meets the requirements
